### PR TITLE
fix out of bounds problem for h5 etc

### DIFF
--- a/renderer.go
+++ b/renderer.go
@@ -3,18 +3,18 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/russross/blackfriday"
-	"github.com/samfoo/ansi"
 	"html"
 	"regexp"
 	"strings"
+
+	"github.com/russross/blackfriday"
+	"github.com/samfoo/ansi"
 )
 
 // Index corresponds to the heading level (e.g. h1, h2, h3...)
 var headerStyles = [...]string{
 	ansi.ColorCode("yellow+bhu"),
 	ansi.ColorCode("yellow+bh"),
-	ansi.ColorCode("yellow"),
 	ansi.ColorCode("yellow"),
 }
 
@@ -66,6 +66,9 @@ func (options *Console) BlockHtml(out *bytes.Buffer, text []byte) {
 
 func (options *Console) Header(out *bytes.Buffer, text func() bool, level int, id string) {
 	out.WriteString("\n")
+	if level < 1 || level > len(headerStyles) {
+		level = len(headerStyles)
+	}
 	out.WriteString(headerStyles[level-1])
 
 	marker := out.Len()


### PR DESCRIPTION
Ran this against a md file that had a level five heading and it crashed.
So I've popped a quick bounds check in to avoid this in future.
At the same time, removed the duplicate h3 and h4 settings in the array, as the bounds limiting will do this anyway.